### PR TITLE
Fix #2: Installing new version of config file /etc/bash_completion.d/lxc error

### DIFF
--- a/scripts/start_docker.sh
+++ b/scripts/start_docker.sh
@@ -97,7 +97,7 @@ echo
 travis_fold start docker.install
   travis_section 'Installing Docker'
   sudo apt-get -y update
-  sudo apt-get -y install lxc lxc-docker slirp
+  sudo apt-get -y install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" lxc lxc-docker slirp
   sudo usermod -aG docker "${USER}"
   sudo service docker stop || true
 travis_fold end docker.install


### PR DESCRIPTION
This takes care of #2:

---

I was testing your repo on travis-ci and the build job got stuck at this point:

```
Installing new version of config file /etc/bash_completion.d/lxc ...
Configuration file '/etc/apparmor.d/abstractions/lxc/container-base'
 ==> Deleted (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** container-base (Y/I/N/O/D/Z) [default=N] ? 
```

example: https://travis-ci.org/saucelabs-ansible/packer/jobs/134279269

any ideas?
